### PR TITLE
stacher.io@6.0.12: Rename-Item fix

### DIFF
--- a/bucket/stacher.io.json
+++ b/bucket/stacher.io.json
@@ -10,7 +10,7 @@
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Update.exe\"; Rename-Item \"$dir\\Stacher-*-full.nupkg\" 'StacherFull.nupkg'",
+        "Remove-Item \"$dir\\Update.exe\"; Get-ChildItem \"$dir\\Stacher-*-full.nupkg\" | ForEach { Rename-Item -Path $_.FullName -newName ('StacherFull.nupkg')}",
         "Expand-7zipArchive \"$dir\\StacherFull.nupkg\" \"$dir\" -ExtractDir 'lib\\net45' -Removal"
     ],
     "shortcuts": [

--- a/bucket/stacher.io.json
+++ b/bucket/stacher.io.json
@@ -10,7 +10,7 @@
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Update.exe\"; Get-ChildItem \"$dir\\Stacher-*-full.nupkg\" | ForEach { Rename-Item -Path $_.FullName -newName ('StacherFull.nupkg')}",
+        "Remove-Item \"$dir\\Update.exe\"; Get-ChildItem \"$dir\\Stacher-*-full.nupkg\" | ForEach-Object { Rename-Item -Path $_.FullName -newName ('StacherFull.nupkg') }",
         "Expand-7zipArchive \"$dir\\StacherFull.nupkg\" \"$dir\" -ExtractDir 'lib\\net45' -Removal"
     ],
     "shortcuts": [

--- a/bucket/stacher.io.json
+++ b/bucket/stacher.io.json
@@ -10,7 +10,7 @@
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Update.exe\"; Get-ChildItem \"$dir\\Stacher-*-full.nupkg\" | ForEach-Object { Rename-Item -Path $_.FullName -newName ('StacherFull.nupkg') }",
+        "Remove-Item \"$dir\\Update.exe\"; Get-ChildItem \"$dir\\Stacher-*-full.nupkg\" | ForEach-Object { Rename-Item -Path $_.FullName -NewName ('StacherFull.nupkg') }",
         "Expand-7zipArchive \"$dir\\StacherFull.nupkg\" \"$dir\" -ExtractDir 'lib\\net45' -Removal"
     ],
     "shortcuts": [


### PR DESCRIPTION
Rename-Item does not work with wildcards. I followed [this Reddit comment's](https://www.reddit.com/r/PowerShell/comments/tzd07b/-/i3yfsn0) code structure to fix the pre_install script. I tested locally and stacher.io now installs properly. Without these changes, PowerShell throws this error and stacher.io does not install:

```
Installing 'stacher.io' (6.0.12) [64bit] from Zliced13_MyScoop bucket
Loading StacherSetup.exe from cache
Checking hash of StacherSetup.exe ... ok.
Extracting dl.7z ... done.
Running pre_install script...
Rename-Item : Cannot process argument because the value of argument "path" is not valid. Change the value of the
"path" argument and run the operation again.
At line:1 char:32
+ ... pdate.exe"; Rename-Item "$dir\Stacher-*-full.nupkg" 'StacherFull.nupk ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Rename-Item], PSArgumentException
    + FullyQualifiedErrorId : Argument,Microsoft.PowerShell.Commands.RenameItemCommand

ERROR Exit code was 2!
Failed to extract files from C:\Apps\Scoop\apps\stacher.io\6.0.12\StacherFull.nupkg.
```

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- Closes #XXXX -->
<!-- or -->
<!-- Relates to #XXXX -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

_This is my first time doing a pull request so apologies if I'm doing something wrong._